### PR TITLE
Generators, slug rewrites and generic collections

### DIFF
--- a/.iiifrc.yml
+++ b/.iiifrc.yml
@@ -3,11 +3,28 @@ server:
 
 # Run these everywhere.
 run:
+  - flat-manifests
+  - extract-remote-source
   - extract-slug-source
   - extract-label-string
   - extract-thumbnail
   - manifest-sqlite
   - metadata-analysis
+  - folder-collections
+
+generators:
+  sts-shuttles:
+    type: nasa-generator
+    config:
+      label: STS Shuttles
+      query: "sts orbit"
+      maxResults: 50
+  curiosity:
+    type: nasa-generator
+    config:
+      label: Curiosity
+      query: "curiosity rover"
+      maxResults: 10
 
 stores:
   manifests:

--- a/lib/scripts.d.ts
+++ b/lib/scripts.d.ts
@@ -1,10 +1,14 @@
 import { Extraction } from "../src/util/extract.ts";
 import { Enrichment } from "../src/util/enrich.ts";
+import { Rewrite } from "../src/util/rewrite.ts";
+import { IIIFGenerator } from "../src/util/iiif-generator.ts";
 
 declare global {
   namespace __hss {
     let extractions: Extraction[] | undefined;
     let enrichments: Enrichment[] | undefined;
+    let rewrites: Rewrite[] | undefined;
+    let generators: IIIFGenerator[] | undefined;
   }
 }
 
@@ -20,4 +24,10 @@ export function enrich(
     invalidate?: Enrichment["invalidate"];
   },
   handler: Enrichment["handler"],
+): void;
+
+export function rewrite(config: Rewrite): void;
+
+export function generator<Config = any, Temp = any>(
+  config: IIIFGenerator<Config, Temp>,
 ): void;

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -23,3 +23,19 @@ export function enrich(config, handler) {
     handler: handler,
   });
 }
+
+export function rewrite(config) {
+  if (!config) return;
+  global.__hss = global.__hss ? global.__hss : {};
+  global.__hss.rewrites = global.__hss.rewrites ? global.__hss.rewrites : [];
+  global.__hss.rewrites.push(config);
+}
+
+export function generator(config) {
+  if (!config) return;
+  global.__hss = global.__hss ? global.__hss : {};
+  global.__hss.generators = global.__hss.generators
+    ? global.__hss.generators
+    : [];
+  global.__hss.generators.push(config);
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iiif-hss",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "IIIF Headless Static Site",
   "type": "module",
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iiif-hss",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "IIIF Headless Static Site",
   "type": "module",
   "keywords": [],

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -35,6 +35,7 @@ import { Enrichment } from "../util/enrich.ts";
 import { extractThumbnail } from "../extract/extract-thumbnail.ts";
 import { extractTopics } from "../extract/extract-topics.ts";
 import { extractMetadataAnalysis } from "../extract/extract-metadata-analysis.ts";
+import { createFiletypeCache } from "../util/file-type-cache.ts";
 // import { pdiiif } from "../enrich/pdiiif.ts";
 
 export type BuildOptions = {
@@ -166,6 +167,8 @@ export async function build(options: BuildOptions, command?: Command) {
     console.log("Done in " + (Date.now() - startTime) + "ms");
   }
 
+  await buildConfig.fileTypeCache.save();
+
   if (options.watch) {
     const watcher = watch(join(cwd(), "content"), { recursive: true });
     const { watch: _watch, scripts, cache, ...nonWatchOptions } = options;
@@ -225,6 +228,8 @@ export async function getBuildConfig(options: BuildOptions) {
   const clearLogger = () => {
     internalLogger = defaultLogger;
   };
+
+  const fileTypeCache = createFiletypeCache(join(cacheDir, "file-types.json"));
 
   // Load external configs / scripts.
   if (options.scripts) {
@@ -299,7 +304,7 @@ export async function getBuildConfig(options: BuildOptions) {
 
   const server = options.dev
     ? { url: env.DEV_SERVER || "http://localhost:7111" }
-    : config.server;
+    : env.SERVER_URL || config.server;
 
   const time = async <T>(label: string, promise: Promise<T>): Promise<T> => {
     const startTime = Date.now();
@@ -349,6 +354,7 @@ export async function getBuildConfig(options: BuildOptions) {
     clearLogger,
     slugs,
     imageServiceLoader,
+    fileTypeCache,
     // Currently hard-coded.
     storeTypes,
   };

--- a/src/commands/build/2-extract.ts
+++ b/src/commands/build/2-extract.ts
@@ -54,6 +54,9 @@ export async function extract(
     totalResources += resource.subResources || 0;
   }
 
+  // Found Collections
+  const collections: Record<string, string[]> = {};
+
   const progress = makeProgressBar("Extraction", totalResources);
 
   for (const manifest of allResources) {
@@ -147,6 +150,12 @@ export async function extract(
         }
         if (result.indices) {
           mergeIndices(newindices, result.indices);
+        }
+        if (result.collections) {
+          result.collections.forEach((collectionSlug) => {
+            collections[collectionSlug] = collections[collectionSlug] || [];
+            collections[collectionSlug].push(manifest.slug);
+          });
         }
       }
 
@@ -347,5 +356,5 @@ export async function extract(
 
   progress.stop();
 
-  return {};
+  return { collections };
 }

--- a/src/commands/build/4-emit.ts
+++ b/src/commands/build/4-emit.ts
@@ -53,7 +53,7 @@ export async function emit(
     savingFiles.push(copy(filesDir, buildDir, { overwrite: true }));
   }
 
-  const configUrl = server?.url;
+  const configUrl = typeof server === "string" ? server : server?.url;
   const indexCollection: Record<string, any> = {};
   const indexCollectionMap: Record<string, any> = {};
   const storeCollections: Record<string, Array<any>> = {};
@@ -183,10 +183,12 @@ export async function emit(
 
         if (resource.items) {
           resource.items = resource.items.map((item: any) => {
-            if (item.type === "Manifest") {
-              item.id = `${configUrl}/${allPaths[item.path]}/manifest.json`;
-            } else {
-              item.id = `${configUrl}/${allPaths[item.path]}/collection.json`;
+            if (allPaths[item.path]) {
+              if (item.type === "Manifest") {
+                item.id = `${configUrl}/${allPaths[item.path]}/manifest.json`;
+              } else {
+                item.id = `${configUrl}/${allPaths[item.path]}/collection.json`;
+              }
             }
             return item;
           });

--- a/src/commands/build/5-indices.ts
+++ b/src/commands/build/5-indices.ts
@@ -34,7 +34,7 @@ export async function indices(
   }
 
   const topLevelCollection: any[] = [];
-  const configUrl = server?.url;
+  const configUrl = typeof server === "string" ? server : server?.url;
 
   const indexMap: Record<string, Record<string, string[]>> = {};
   for (const resource of allResources) {

--- a/src/commands/build/5-indices.ts
+++ b/src/commands/build/5-indices.ts
@@ -18,6 +18,7 @@ export async function indices(
     siteMap,
     editable,
     overrides,
+    collections,
   }: {
     allResources: Array<ActiveResourceJson>;
     indexCollection?: Record<string, any>;
@@ -26,6 +27,7 @@ export async function indices(
     siteMap?: Record<string, { type: string; source: any; label?: string }>;
     editable?: Record<string, string>;
     overrides?: Record<string, string>;
+    collections?: Record<string, string[]>;
   },
   { options, server, buildDir, config, cacheDir, topicsDir }: BuildConfig,
 ) {
@@ -35,6 +37,38 @@ export async function indices(
 
   const topLevelCollection: any[] = [];
   const configUrl = typeof server === "string" ? server : server?.url;
+
+  if (collections && indexCollection) {
+    const collectionSlugs = Object.keys(collections);
+    for (let collectionSlug of collectionSlugs) {
+      const manifestSlugs = collections[collectionSlug];
+      if (!collectionSlug.startsWith("collections/")) {
+        collectionSlug = `collections/${collectionSlug}`;
+      }
+
+      const collectionSnippet = createCollection({
+        configUrl,
+        slug: collectionSlug,
+        label: collectionSlug,
+      });
+      const collection = {
+        ...collectionSnippet,
+        items: manifestSlugs
+          .map((slug) => {
+            return indexCollection[slug];
+          })
+          .filter(Boolean),
+      };
+
+      (collectionSnippet as any)["hss:totalItems"] = collection["items"].length;
+      await Bun.write(
+        join(buildDir, collectionSlug, "collection.json"),
+        JSON.stringify(collection, null, 2),
+      );
+
+      topLevelCollection.push(collectionSnippet);
+    }
+  }
 
   const indexMap: Record<string, Record<string, string[]>> = {};
   for (const resource of allResources) {

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,0 +1,196 @@
+import { getConfig } from "../util/get-config.ts";
+import { loadScripts } from "../util/load-scripts.ts";
+import { getNodeGlobals } from "../util/get-node-globals.ts";
+import { Command } from "commander";
+import { IIIFGenerator } from "../util/iiif-generator.ts";
+import { nasaGenerator } from "../generator/nasa-generator.ts";
+import { join } from "node:path";
+import { mkdirp } from "mkdirp";
+import { loadJson } from "../util/load-json.ts";
+import { existsSync } from "fs";
+import { lazyValue, LazyValue } from "../util/lazy-value.ts";
+// @ts-ignore
+import { IIIFBuilder } from "iiif-builder";
+import { makeProgressBar } from "../util/make-progress-bar.ts";
+import { cwd } from "node:process";
+import { createStoreRequestCache } from "../util/store-request-cache.ts";
+
+interface GenerateOptions {
+  scripts?: string;
+  debug?: boolean;
+  cache?: boolean;
+}
+
+const defaultGenerators: IIIFGenerator[] = [
+  //
+  nasaGenerator,
+];
+
+export const defaultCacheDir = `./.iiif/_generator`;
+
+export async function generate(options: GenerateOptions, command?: Command) {
+  const config = await getConfig();
+
+  await loadScripts(options);
+  const globals = getNodeGlobals();
+  const generatorDirectory = join(cwd(), defaultCacheDir);
+  const allGenerators = [...defaultGenerators, ...globals.generators];
+
+  await mkdirp(generatorDirectory);
+  let savingFiles: Promise<any>[] = [];
+  const saveJson = (file: string, contents: any) => {
+    savingFiles.push(Bun.write(file, JSON.stringify(contents, null, 2)));
+  };
+  const waitSavingFiles = async () => {
+    await Promise.all(savingFiles);
+    savingFiles = [];
+  };
+
+  let totalResources = 0;
+
+  if (config.generators) {
+    const generators = Object.keys(config.generators);
+    for (const generatorName of generators) {
+      const generator = config.generators[generatorName];
+      const generatorType = generator.type;
+      const generatorConfig = generator.config || {};
+
+      const foundGenerator = allGenerators.find((g) => g.id === generatorType);
+
+      if (!foundGenerator) {
+        throw new Error(`Unknown generator type: ${generatorType}`);
+      }
+
+      const buildDirectory = generator.output
+        ? join(cwd(), generator.output)
+        : join(generatorDirectory, generatorName, "build");
+      const cacheDirectory = join(generatorDirectory, generatorName);
+      const resourcesDirectory = join(cacheDirectory, "resources");
+      const requestCache = createStoreRequestCache(
+        `requests`,
+        cacheDirectory,
+        !options.cache,
+      );
+
+      await mkdirp(cacheDirectory);
+      await mkdirp(buildDirectory);
+
+      const globalCacheFile = join(cacheDirectory, "cache.json");
+      const globalCache = lazyValue(() => loadJson(globalCacheFile));
+      const generatorApi = {
+        config: generatorConfig,
+        caches: globalCache,
+        cacheDirectory,
+        saveJson: (file: string, contents: any) =>
+          saveJson(join(buildDirectory, file), contents),
+        builder: new IIIFBuilder(),
+        requestCache,
+      };
+      const resources = await foundGenerator.prepare(generatorApi);
+      const resourceCaches: Record<string, LazyValue<any>> = {};
+      const invalidateMap: Record<string, boolean> = {};
+
+      const progress = makeProgressBar(
+        `Generating ${generator.type} using ${foundGenerator.name}`,
+        resources.length,
+      );
+
+      totalResources += resources.length;
+
+      let globalInvalidate = false;
+      // First check if we need to invalidate everything
+      let invalidate = foundGenerator.invalidate
+        ? await foundGenerator.invalidate(resources, generatorApi)
+        : !existsSync(globalCacheFile);
+
+      globalInvalidate = globalInvalidate || invalidate;
+
+      if (!invalidate) {
+        for (const resource of resources) {
+          if (!resource.id) {
+            throw new Error(`Resource ${resource.type} has no id`);
+          }
+          const resourceCacheFile = join(
+            resourcesDirectory,
+            resource.id,
+            "cache.json",
+          );
+          resourceCaches[resource.id] = lazyValue(() =>
+            loadJson(resourceCacheFile),
+          );
+
+          invalidateMap[resource.id] = foundGenerator.invalidateEach
+            ? await foundGenerator.invalidateEach(resource, generatorApi)
+            : existsSync(resourceCacheFile);
+
+          globalInvalidate = globalInvalidate || invalidateMap[resource.id];
+        }
+      }
+
+      for (const resource of resources) {
+        const shouldRun = invalidate || invalidateMap[resource.id];
+        if (!shouldRun) {
+          progress.increment();
+          continue;
+        }
+
+        const resourceCache = resourceCaches[resource.id];
+        const resourceDirectory = join(resourcesDirectory, resource.id);
+        const generateApi = {
+          config: generatorConfig,
+          caches: resourceCache,
+          cacheDirectory: resourceDirectory,
+          saveJson: (file: string, contents: any) =>
+            saveJson(join(buildDirectory, file), contents),
+          builder: new IIIFBuilder(),
+          requestCache,
+        };
+
+        await mkdirp(resourceDirectory);
+
+        const response = foundGenerator.generateEach
+          ? await foundGenerator.generateEach(
+              resource,
+              buildDirectory,
+              generateApi,
+            )
+          : { cache: {} };
+
+        const cache = response.cache || {};
+
+        progress.increment();
+        saveJson(join(resourceDirectory, "cache.json"), cache);
+      }
+      await waitSavingFiles();
+
+      if (foundGenerator.generate && globalInvalidate) {
+        const response = await foundGenerator.generate(
+          resources,
+          cacheDirectory,
+          generatorApi,
+        );
+
+        const cache = response.cache || {};
+
+        // @todo - do something with the store?
+        const store = response.store || {};
+
+        saveJson(join(cacheDirectory, "cache.json"), cache);
+      }
+      await waitSavingFiles();
+
+      if (foundGenerator.postGenerate) {
+        await foundGenerator.postGenerate(
+          resources,
+          cacheDirectory,
+          generatorApi,
+        );
+      }
+
+      await waitSavingFiles();
+      progress.stop();
+    }
+
+    console.log(`Generated ${totalResources} resources`);
+  }
+}

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -15,6 +15,8 @@ export async function serve({ dev, scripts }: ServeOptions) {
     enrich: true,
     extract: true,
     emit: true,
+    generate: true,
+    cache: true,
     scripts,
   };
 

--- a/src/extract/extract-folder-collections.ts
+++ b/src/extract/extract-folder-collections.ts
@@ -1,0 +1,20 @@
+import { Extraction } from "../util/extract.ts";
+
+export const extractFolderCollections: Extraction = {
+  id: "folder-collections",
+  name: "Folder Collections",
+  types: ["Manifest"],
+  invalidate: async () => true,
+  async handler(resource, api) {
+    if (resource.source.type !== "disk") return {};
+
+    const filePath = resource.source.relativePath;
+    if (filePath) {
+      return {
+        collections: [filePath],
+      };
+    }
+
+    return {};
+  },
+};

--- a/src/extract/extract-remote-source.ts
+++ b/src/extract/extract-remote-source.ts
@@ -1,0 +1,17 @@
+import { Extraction } from "../util/extract.ts";
+
+export const extractRemoteSource: Extraction = {
+  id: "extract-remote-source",
+  name: "Extract remote source",
+  types: ["Manifest", "Collection"],
+  invalidate: async () => true,
+  handler: async (resource) => {
+    if (resource.source.type === "remote") {
+      const { type, url } = resource.source;
+      return {
+        meta: { url },
+      };
+    }
+    return {};
+  },
+};

--- a/src/generator/nasa-generator.ts
+++ b/src/generator/nasa-generator.ts
@@ -1,0 +1,87 @@
+import { GeneratorReference, IIIFGenerator } from "../util/iiif-generator.ts";
+import { NASA } from "./nasa-generator/NASA.ts";
+import {
+  CollectionResponse,
+  SearchCollectionItem,
+} from "./nasa-generator/NASA.types.ts";
+import { assetToManifest } from "./nasa-generator/asset-to-manifest.ts";
+
+export const nasaGenerator: IIIFGenerator<
+  { testing: boolean; opt?: string },
+  { query: string; maxPages?: number; maxResults?: number }
+> = {
+  id: "nasa-generator",
+  name: "NASA Generator",
+  async prepare(gen) {
+    const api = new NASA(gen.requestCache.fetch);
+    const q = gen.config.query;
+    const maxPages = gen.config.maxPages || 1;
+    const maxResults = gen.config.maxResults || 50;
+
+    const search = await api.search({
+      description: q,
+      media_type: ["image"],
+      page: 1,
+    });
+
+    const foundResources: GeneratorReference[] = [];
+    let nextPage = search.collection.links.find((l) => l.rel === "next");
+    let currentChecked = 1;
+    let currentResults = 0;
+
+    for (const result of search.collection.items) {
+      const item = result.data[0];
+      currentResults++;
+      if (currentResults > maxResults) break;
+      foundResources.push({
+        id: item.nasa_id,
+        type: "Manifest",
+        data: item,
+      });
+    }
+
+    while (nextPage && currentChecked <= maxPages) {
+      const next = await api.link<CollectionResponse<SearchCollectionItem>>(
+        nextPage.href,
+      );
+      for (const result of next.collection.items) {
+        currentResults++;
+        if (currentResults > maxResults) break;
+        const item = result.data[0];
+        foundResources.push({
+          id: item.nasa_id,
+          type: "Manifest",
+          data: item,
+        });
+      }
+      nextPage = next.collection.links.find((l) => l.rel === "next");
+      currentChecked++;
+    }
+
+    // Always called, even if there is nothing to run.
+    return foundResources;
+  },
+
+  async generateEach(resource, directory, api) {
+    const nasa = new NASA(api.requestCache.fetch);
+    const fullData = await nasa.asset(resource.id);
+
+    const manifest = await assetToManifest(
+      resource.id,
+      fullData,
+      nasa,
+      api.builder,
+      "https://example.org/",
+    );
+
+    api.saveJson(`${resource.id}.json`, manifest);
+
+    // This will be called once per item in the prepare step.
+    return {
+      cache: {
+        resource,
+        fullData,
+      },
+    };
+  },
+};

--- a/src/generator/nasa-generator/NASA.ts
+++ b/src/generator/nasa-generator/NASA.ts
@@ -1,0 +1,50 @@
+import {
+  AssetResponse,
+  CollectionResponse,
+  SearchCollectionItem,
+  SearchParams,
+} from "./NASA.types";
+import { queryStringStringify } from "./query-string-stringify";
+
+export class NASA {
+  static BASE_URL = "https://images-api.nasa.gov";
+
+  fetcher: any;
+
+  constructor(fetcher: any) {
+    this.fetcher = fetcher;
+  }
+
+  async search(
+    params: SearchParams,
+  ): Promise<CollectionResponse<SearchCollectionItem>> {
+    const reqUrl = new URL(`${NASA.BASE_URL}/search`);
+    reqUrl.search = queryStringStringify(params);
+
+    const response = await fetch(reqUrl.toString(), {
+      headers: {
+        Accept: "application/json",
+      },
+    });
+
+    return (await response.json()) as any;
+  }
+
+  async asset(nasa_id: string): Promise<AssetResponse> {
+    return this.fetcher(`${NASA.BASE_URL}/asset/${nasa_id}`, {
+      headers: { Accept: "application/json" },
+    });
+  }
+  async assetMetadata(nasa_id: string) {
+    return this.fetcher(`${NASA.BASE_URL}/asset/${nasa_id}/metadata.json`, {
+      headers: { Accept: "application/json" },
+    });
+  }
+  async link<T>(_link: string): Promise<T> {
+    const url = new URL(_link);
+    url.protocol = "https";
+    const link = url.toString();
+
+    return this.fetcher(link, { headers: { Accept: "application/json" } });
+  }
+}

--- a/src/generator/nasa-generator/NASA.types.ts
+++ b/src/generator/nasa-generator/NASA.types.ts
@@ -1,0 +1,465 @@
+export interface SearchParams {
+  q?: string;
+  center?: string;
+  description?: string;
+  description_508?: string;
+  keywords?: string[];
+  location?: string;
+  media_type?: MediaTypes[];
+  nasa_id?: string;
+  page?: number;
+  photographer?: string;
+  secondary_creator?: string;
+  title?: string;
+  year_start?: number;
+  year_end?: number;
+}
+
+type MediaTypes = 'image' | 'audio';
+
+export interface AssetResponse {
+  collection: {
+    version: string;
+    href: string;
+    items: Array<Link>;
+  };
+}
+
+export interface CollectionResponse<T> {
+  collection: {
+    href: string;
+    items: Array<CollectionItem<T>>;
+    links: Array<Link>;
+    metadata: {
+      total_hits: number;
+    };
+    version: string;
+  };
+}
+
+export interface SearchCollectionItem {
+  center: string;
+  date_created: string;
+  description: string;
+  keywords: string[];
+  media_type: MediaTypes;
+  nasa_id: string;
+  title: string;
+}
+
+export interface Link {
+  href: string;
+  rel?: string;
+  render?: string; // image
+}
+
+export interface CollectionItem<T> {
+  data: Array<T>;
+  href: string;
+  links: Array<Link>;
+}
+
+export interface XMP {
+  'XMP:AlreadyApplied': string;
+  'XMP:ApertureValue': string;
+  'XMP:ApproximateFocusDistance': string;
+  'XMP:AutoLateralCA': string;
+  'XMP:Blacks2012': string;
+  'XMP:BlueHue': string;
+  'XMP:BlueSaturation': string;
+  'XMP:Brightness': string;
+  'XMP:CameraProfile': string;
+  'XMP:CaptionWriter': string;
+  'XMP:City': string;
+  'XMP:Clarity': string;
+  'XMP:Clarity2012': string;
+  'XMP:ColorNoiseReduction': string;
+  'XMP:ColorNoiseReductionDetail': string;
+  'XMP:ColorTemperature': string;
+  'XMP:Contrast': string;
+  'XMP:Contrast2012': string;
+  'XMP:ConvertToGrayscale': boolean;
+  'XMP:Country': string;
+  'XMP:CreateDate': string;
+  'XMP:Creator': string[];
+  'XMP:CreatorAddress': string;
+  'XMP:CreatorCity': string;
+  'XMP:CreatorCountry': string;
+  'XMP:CreatorRegion': string;
+  'XMP:CreatorTool': string;
+  'XMP:CreatorWorkURL': string;
+  'XMP:Credit': string;
+  'XMP:CropAngle': string;
+  'XMP:CropBottom': string;
+  'XMP:CropConstrainToWarp': string;
+  'XMP:CropHeight': string;
+  'XMP:CropLeft': string;
+  'XMP:CropRight': string;
+  'XMP:CropTop': string;
+  'XMP:CropUnit': string;
+  'XMP:CropWidth': string;
+  'XMP:CustomRendered': string;
+  'XMP:DateCreated': string;
+  'XMP:DateTimeDigitized': string;
+  'XMP:DateTimeOriginal': string;
+  'XMP:Defringe': string;
+  'XMP:DerivedFromDocumentID': string;
+  'XMP:DerivedFromOriginalDocumentID': string;
+  'XMP:Description': string;
+  'XMP:DocumentID': string;
+  'XMP:ExifVersion': string;
+  'XMP:Exposure': string;
+  'XMP:Exposure2012': number;
+  'XMP:ExposureCompensation': string;
+  'XMP:ExposureMode': string;
+  'XMP:ExposureProgram': string;
+  'XMP:ExposureTime': string;
+  'XMP:FNumber': string;
+  'XMP:FillLight': string;
+  'XMP:Firmware': string;
+  'XMP:FlashCompensation': string;
+  'XMP:FlashFunction': boolean;
+  'XMP:FlashMode': string;
+  'XMP:FlashRedEyeMode': string;
+  'XMP:FlashReturn': string;
+  'XMP:FocalLength': string;
+  'XMP:Format': string;
+  'XMP:GrainAmount': string;
+  'XMP:GreenHue': string;
+  'XMP:GreenSaturation': string;
+  'XMP:HasCrop': string;
+  'XMP:HasSettings': boolean;
+  'XMP:HierarchicalSubject': string;
+  'XMP:HighlightRecovery': string;
+  'XMP:Highlights2012': string;
+  'XMP:History': any[];
+  'XMP:HistoryAction': string;
+  'XMP:HistoryChanged': string[];
+  'XMP:HistoryInstanceID': string;
+  'XMP:HistoryParameters': string;
+  'XMP:HistorySoftwareAgent': string;
+  'XMP:HistoryWhen': string;
+  'XMP:HueAdjustmentAqua': number;
+  'XMP:HueAdjustmentBlue': number;
+  'XMP:HueAdjustmentGreen': number;
+  'XMP:HueAdjustmentMagenta': number;
+  'XMP:HueAdjustmentOrange': number;
+  'XMP:HueAdjustmentPurple': number;
+  'XMP:HueAdjustmentRed': number;
+  'XMP:HueAdjustmentYellow': number;
+  'XMP:ISO': string;
+  'XMP:ImageNumber': string;
+  'XMP:InstanceID': string;
+  'XMP:Instructions': string;
+  'XMP:Lens': string;
+  'XMP:LensID': string;
+  'XMP:LensInfo': string;
+  'XMP:LensManualDistortionAmount': string;
+  'XMP:LensProfileEnable': string;
+  'XMP:LensProfileSetup': string;
+  'XMP:Location': string;
+  'XMP:LuminanceAdjustmentAqua': number;
+  'XMP:LuminanceAdjustmentBlue': number;
+  'XMP:LuminanceAdjustmentGreen': number;
+  'XMP:LuminanceAdjustmentMagenta': number;
+  'XMP:LuminanceAdjustmentOrange': number;
+  'XMP:LuminanceAdjustmentPurple': number;
+  'XMP:LuminanceAdjustmentRed': number;
+  'XMP:LuminanceAdjustmentYellow': number;
+  'XMP:LuminanceSmoothing': string;
+  'XMP:MaxApertureValue': string;
+  'XMP:MetadataDate': string;
+  'XMP:MeteringMode': string;
+  'XMP:Model': string;
+  'XMP:ModifyDate': string;
+  'XMP:OriginalDocumentID': string;
+  'XMP:ParametricDarks': string;
+  'XMP:ParametricHighlightSplit': string;
+  'XMP:ParametricHighlights': string;
+  'XMP:ParametricLights': string;
+  'XMP:ParametricMidtoneSplit': string;
+  'XMP:ParametricShadowSplit': string;
+  'XMP:ParametricShadows': string;
+  'XMP:PerspectiveHorizontal': string;
+  'XMP:PerspectiveRotate': string;
+  'XMP:PerspectiveScale': string;
+  'XMP:PerspectiveVertical': string;
+  'XMP:PostCropVignetteAmount': string;
+  'XMP:PostCropVignetteFeather': string;
+  'XMP:PostCropVignetteHighlightContrast': string;
+  'XMP:PostCropVignetteMidpoint': string;
+  'XMP:PostCropVignetteRoundness': string;
+  'XMP:PostCropVignetteStyle': string;
+  'XMP:ProcessVersion': string;
+  'XMP:Rating': string;
+  'XMP:RedHue': string;
+  'XMP:RedSaturation': string;
+  'XMP:Rights': string;
+  'XMP:Saturation': string;
+  'XMP:SaturationAdjustmentAqua': string;
+  'XMP:SaturationAdjustmentBlue': string;
+  'XMP:SaturationAdjustmentGreen': string;
+  'XMP:SaturationAdjustmentMagenta': string;
+  'XMP:SaturationAdjustmentOrange': string;
+  'XMP:SaturationAdjustmentPurple': string;
+  'XMP:SaturationAdjustmentRed': string;
+  'XMP:SaturationAdjustmentYellow': string;
+  'XMP:SceneCaptureType': string;
+  'XMP:SerialNumber': string;
+  'XMP:ShadowTint': string;
+  'XMP:Shadows': string;
+  'XMP:Shadows2012': string;
+  'XMP:SharpenDetail': string;
+  'XMP:SharpenEdgeMasking': string;
+  'XMP:SharpenRadius': string;
+  'XMP:Sharpness': string;
+  'XMP:Source': string;
+  'XMP:SplitToningBalance': string;
+  'XMP:SplitToningHighlightHue': string;
+  'XMP:SplitToningHighlightSaturation': string;
+  'XMP:SplitToningShadowHue': string;
+  'XMP:SplitToningShadowSaturation': string;
+  'XMP:State': string;
+  'XMP:Subject': string[];
+  'XMP:Tint': string;
+  'XMP:Title': string;
+  'XMP:ToneCurve': string;
+  'XMP:ToneCurveBlue': string;
+  'XMP:ToneCurveGreen': string;
+  'XMP:ToneCurveName': string;
+  'XMP:ToneCurveName2012': string;
+  'XMP:ToneCurvePV2012': string[];
+  'XMP:ToneCurvePV2012Blue': string[];
+  'XMP:ToneCurvePV2012Green': string[];
+  'XMP:ToneCurvePV2012Red': string[];
+  'XMP:ToneCurveRed': string[];
+  'XMP:TransmissionReference': string;
+  'XMP:Version': string;
+  'XMP:Vibrance': string;
+  'XMP:VignetteAmount': string;
+  'XMP:WhiteBalance': string;
+  'XMP:WebStatement': string;
+  'XMP:XMPToolkit': string;
+  'XMP:CreatorContactInfo': any;
+  'XMP:DerivedFrom': any;
+  'XMP:UsageTerms': string;
+}
+export interface AVAIL {
+  'AVAIL:Album': string | string[];
+  'AVAIL:Center': string;
+  'AVAIL:DateCreated': string;
+  'AVAIL:Description': string;
+  'AVAIL:Description508': string;
+  'AVAIL:Keywords': string[];
+  'AVAIL:Location': string;
+  'AVAIL:MediaType': string;
+  'AVAIL:Owner': string;
+  'AVAIL:Photographer': string;
+  'AVAIL:Title': string;
+  'AVAIL:NASAID': string;
+  'AVAIL:SecondaryCreator': string;
+}
+export interface IPTC {
+  'IPTC:By-line': string;
+  'IPTC:Province-State': string;
+  'IPTC:OriginalTransmissionReference': string;
+  'IPTC:Country-PrimaryLocationName': string;
+  'IPTC:City': string;
+  'IPTC:DateCreated': string;
+  'IPTC:DigitalCreationTime': string;
+  'IPTC:CopyrightNotice': string;
+  'IPTC:Writer-Editor': string;
+  'IPTC:ObjectName': string;
+  'IPTC:CodedCharacterSet': string;
+  'IPTC:ApplicationRecordVersion': number;
+  'IPTC:Sub-location': string;
+  'IPTC:DigitalCreationDate': string;
+  'IPTC:Source': string;
+  'IPTC:SpecialInstructions': string;
+  'IPTC:Caption-Abstract': string;
+  'IPTC:Keywords': string[];
+  'IPTC:Credit': string;
+  'IPTC:TimeCreated': string;
+}
+export interface IIC_Profile {
+  'ICC_Profile:BlueMatrixColumn': string;
+  'ICC_Profile:BlueTRC': string;
+  'ICC_Profile:CMMFlags': string;
+  'ICC_Profile:ColorSpaceData': string;
+  'ICC_Profile:ConnectionSpaceIlluminant': string;
+  'ICC_Profile:DeviceAttributes': string;
+  'ICC_Profile:DeviceManufacturer': string;
+  'ICC_Profile:DeviceModel': string;
+  'ICC_Profile:GreenMatrixColumn': string;
+  'ICC_Profile:GreenTRC': string;
+  'ICC_Profile:MediaBlackPoint': string;
+  'ICC_Profile:MediaWhitePoint': string;
+  'ICC_Profile:PrimaryPlatform': string;
+  'ICC_Profile:ProfileCMMType': string;
+  'ICC_Profile:ProfileClass': string;
+  'ICC_Profile:ProfileConnectionSpace': string;
+  'ICC_Profile:ProfileCopyright': string;
+  'ICC_Profile:ProfileCreator': string;
+  'ICC_Profile:ProfileDateTime': string;
+  'ICC_Profile:ProfileDescription': string;
+  'ICC_Profile:ProfileFileSignature': string;
+  'ICC_Profile:ProfileID': number;
+  'ICC_Profile:ProfileVersion': string;
+  'ICC_Profile:RedMatrixColumn': string;
+  'ICC_Profile:RedTRC': string;
+  'ICC_Profile:RenderingIntent': string;
+  'ICC_Profile:ViewingCondDesc': string;
+  'ICC_Profile:MeasurementGeometry': string;
+  'ICC_Profile:DeviceModelDesc': string;
+  'ICC_Profile:MeasurementIlluminant': string;
+  'ICC_Profile:MeasurementFlare': string;
+  'ICC_Profile:Luminance': string;
+  'ICC_Profile:MeasurementBacking': string;
+  'ICC_Profile:DeviceMfgDesc': string;
+  'ICC_Profile:ViewingCondIlluminantType': string;
+  'ICC_Profile:ViewingCondSurround': string;
+  'ICC_Profile:ViewingCondIlluminant': string;
+  'ICC_Profile:MeasurementObserver': string;
+  'ICC_Profile:Technology': string;
+}
+export interface Photoshop {
+  'Photoshop:IPTCDigest': string;
+  'Photoshop:PhotoshopThumbnail': string;
+  'Photoshop:DisplayedUnitsY': string;
+  'Photoshop:PhotoshopQuality': number;
+  'Photoshop:URL': string;
+  'Photoshop:PhotoshopFormat': string;
+  'Photoshop:ProgressiveScans': string;
+  'Photoshop:GlobalAltitude': number;
+  'Photoshop:GlobalAngle': number;
+  'Photoshop:YResolution': number;
+  'Photoshop:DisplayedUnitsX': string;
+  'Photoshop:XResolution': number;
+}
+
+export interface EXIF {
+  'EXIF:ApertureValue': number;
+  'EXIF:Artist': string;
+  'EXIF:BitsPerSample': string;
+  'EXIF:ColorSpace': string;
+  'EXIF:Compression': string;
+  'EXIF:Copyright': string;
+  'EXIF:Contrast': string;
+  'EXIF:CreateDate': string;
+  'EXIF:CustomRendered': string;
+  'EXIF:DateTimeOriginal': string;
+  'EXIF:ExifVersion': string;
+  'EXIF:ExposureCompensation': number;
+  'EXIF:ExposureMode': string;
+  'EXIF:ExposureProgram': string;
+  'EXIF:ExposureTime': string;
+  'EXIF:FNumber': number;
+  'EXIF:Flash': string;
+  'EXIF:FocalLength': string;
+  'EXIF:FocalPlaneResolutionUnit': string;
+  'EXIF:FocalPlaneYResolution': string;
+  'EXIF:GainControl': string;
+  'EXIF:ISO': string;
+  'EXIF:ImageDescription': string;
+  'EXIF:ImageHeight': string;
+  'EXIF:ImageWidth': string;
+  'EXIF:LensInfo': string;
+  'EXIF:LensModel': string;
+  'EXIF:Make': string;
+  'EXIF:MaxApertureValue': number;
+  'EXIF:MeteringMode': string;
+  'EXIF:Model': string;
+  'EXIF:ModifyDate': string;
+  'EXIF:Orientation': string;
+  'EXIF:PhotometricInterpretation': string;
+  'EXIF:PlanarConfiguration': string;
+  'EXIF:Predictor': string;
+  'EXIF:ResolutionUnit': string;
+  'EXIF:RowsPerStrip': string;
+  'EXIF:SamplesPerPixel': string;
+  'EXIF:SerialNumber': string;
+  'EXIF:ShutterSpeedValue': string;
+  'EXIF:Software': string;
+  'EXIF:StripByteCounts': string;
+  'EXIF:StripOffsets': string;
+  'EXIF:SubfileType': string;
+  'EXIF:WhiteBalance': string;
+  'EXIF:XResolution': number;
+  'EXIF:YResolution': number;
+  'ExifTool:ExifToolVersion': number;
+  'EXIF:ExifImageHeight': number;
+  'EXIF:FlashpixVersion': string;
+  'EXIF:CompressedBitsPerPixel': number;
+  'EXIF:SceneType': string;
+  'EXIF:InteropIndex': string;
+  'EXIF:SubjectDistanceRange': string;
+  'EXIF:Saturation': string;
+  'EXIF:InteropVersion': string;
+  'EXIF:SensingMethod': string;
+  'EXIF:FocalLengthIn35mmFormat': string;
+  'EXIF:YCbCrPositioning': string;
+  'EXIF:ComponentsConfiguration': string;
+  'EXIF:FileSource': string;
+  'EXIF:CFAPattern': string;
+  'EXIF:ExifImageWidth': number;
+  'EXIF:SceneCaptureType': string;
+  'EXIF:DigitalZoomRatio': number;
+  'EXIF:ThumbnailLength': number;
+  'EXIF:LightSource': string;
+  'EXIF:ThumbnailOffset': number;
+  'EXIF:Sharpness': string;
+}
+export interface Composite {
+  'Composite:Aperture': number;
+  'Composite:CircleOfConfusion': string;
+  'Composite:DigitalCreationDateTime': string;
+  'Composite:FOV': string;
+  'Composite:Flash': string;
+  'Composite:FocalLength35efl': string;
+  'Composite:HyperfocalDistance': string;
+  'Composite:ImageSize': string;
+  'Composite:LensID': string;
+  'Composite:LightValue': number;
+  'Composite:ScaleFactor35efl': number;
+  'Composite:ShutterSpeed': string;
+  'Composite:ThumbnailImage': string;
+  'Composite:Megapixels': number;
+  'Composite:DateTimeCreated': string;
+}
+
+export interface File {
+  'File:BitsPerSample': number;
+  'File:CurrentIPTCDigest': string;
+  'File:ExifByteOrder': string;
+  'File:FileAccessDate': string;
+  'File:FileInodeChangeDate': string;
+  'File:FileModifyDate': string;
+  'File:FileName': string;
+  'File:FilePermissions': string;
+  'File:FileSize': string;
+  'File:FileType': string;
+  'File:MIMEType': string;
+  'File:EncodingProcess': string;
+  'File:ColorComponents': number;
+  'File:ImageHeight': number;
+  'File:FileTypeExtension': string;
+  'File:YCbCrSubSampling': string;
+  'File:ImageWidth': number;
+}
+
+export interface JFIF {
+  'JFIF:YResolution': number;
+  'JFIF:ResolutionUnit': string;
+  'JFIF:XResolution': number;
+  'JFIF:JFIFVersion': number;
+}
+
+export interface Misc {
+  'APP14:APP14Flags1': string;
+  SourceFile: string;
+  'APP14:ColorTransform': string;
+  'APP14:DCTEncodeVersion': number;
+  'APP14:APP14Flags0': string;
+}
+
+export type Asset = Partial<XMP & IIC_Profile & File & AVAIL & IPTC & EXIF & Photoshop & Composite & JFIF & Misc>;

--- a/src/generator/nasa-generator/asset-to-manifest.ts
+++ b/src/generator/nasa-generator/asset-to-manifest.ts
@@ -1,0 +1,138 @@
+import { Asset, AssetResponse } from "./NASA.types.ts";
+import { NASA } from "./NASA.ts";
+// @ts-ignore
+import { IIIFBuilder } from "iiif-builder";
+
+export async function assetToManifest(
+  nasaId: string,
+  asset: AssetResponse,
+  api: NASA,
+  // @ts-ignore
+  builder: IIIFBuilder,
+  baseUrl: string,
+) {
+  const metadataLink = asset.collection.items.find((i: any) =>
+    i.href.endsWith("metadata.json"),
+  );
+  const thumbnailLink = asset.collection.items.find((i: any) =>
+    i.href.endsWith("~thumb.jpg"),
+  );
+  const originalLink = asset.collection.items.find(
+    (i: any) => i.href.indexOf("~orig.") !== -1,
+  );
+
+  if (!metadataLink || !originalLink) {
+    return null;
+  }
+
+  const metadata = await api.link<Asset>(
+    (asset as any).collection.items.find((i: any) =>
+      i.href.endsWith("metadata.json"),
+    ).href,
+  );
+
+  // Things we want.
+  const title =
+    metadata["AVAIL:Title"] ||
+    metadata["XMP:Title"] ||
+    metadata["IPTC:ObjectName"];
+  const description =
+    metadata["EXIF:ImageDescription"] ||
+    metadata["AVAIL:Description"] ||
+    metadata["XMP:Description"] ||
+    metadata["IPTC:Caption-Abstract"];
+  // Metadata keys.
+  const location = metadata["AVAIL:Location"] || metadata["XMP:Location"];
+  const subjectTree = metadata["XMP:HierarchicalSubject"];
+  const copyright = metadata["XMP:Rights"] || metadata["EXIF:Copyright"];
+  const credit = metadata["IPTC:Credit"] || metadata["XMP:Credit"];
+  const lensMode = metadata["EXIF:LensModel"];
+  const subjects =
+    metadata["AVAIL:Keywords"] ||
+    metadata["IPTC:Keywords"] ||
+    metadata["XMP:Subject"];
+  const dateCreated =
+    metadata["IPTC:DateCreated"] ||
+    metadata["XMP:DateCreated"] ||
+    metadata["AVAIL:DateCreated"];
+
+  const width =
+    metadata["File:ImageWidth"] ||
+    metadata["EXIF:ImageWidth"] ||
+    metadata["EXIF:ExifImageWidth"] ||
+    1024;
+  const height =
+    metadata["File:ImageHeight"] ||
+    metadata["EXIF:ImageHeight"] ||
+    metadata["EXIF:ExifImageHeight"] ||
+    1024;
+
+  const created = dateCreated ? new Date(dateCreated) : null;
+
+  const manifestId = `${baseUrl}/${nasaId}.json`;
+  const builtManifest = builder.createManifest(manifestId, (manifest: any) => {
+    manifest.addLabel(title || `Image ${nasaId}`, "en");
+    if (description) {
+      manifest.addSummary(description, "en");
+    }
+
+    description &&
+      manifest.addMetadata({ en: ["Summary"] }, { en: [description] });
+    location && manifest.addMetadata({ en: ["Location"] }, { en: [location] });
+    subjectTree &&
+      manifest.addMetadata({ en: ["Subject tree"] }, { en: [subjectTree] });
+    subjects && manifest.addMetadata({ en: ["Subjects"] }, { en: subjects });
+    credit &&
+      manifest.addMetadata({ en: ["Image credit"] }, { en: credit.split("/") });
+    created &&
+      !Number.isNaN(created.getFullYear()) &&
+      manifest.addMetadata(
+        { en: ["Year"] },
+        { en: [`${created.getFullYear()}`] },
+      );
+    dateCreated &&
+      manifest.addMetadata({ en: ["Date"] }, { en: [dateCreated] });
+    lensMode && manifest.addMetadata({ en: ["Lens"] }, { en: [lensMode] });
+
+    if (copyright) {
+      manifest.setRequiredStatement({
+        label: { en: ["Copyright"] },
+        value: { en: [copyright] },
+      });
+    } else if (credit) {
+      manifest.setRequiredStatement({
+        label: { en: ["Credit"] },
+        value: { en: [credit] },
+      });
+    }
+
+    manifest.createCanvas(`${manifestId}/c0`, (canvas: any) => {
+      canvas.addLabel(title || `Image ${nasaId}`, "en");
+
+      canvas.setWidth(width as number);
+      canvas.setHeight(height as number);
+
+      if (thumbnailLink) {
+        canvas.addThumbnail({
+          id: thumbnailLink.href,
+          type: "Image",
+        });
+      }
+
+      canvas.createAnnotation(`${manifestId}/c0/annotation`, {
+        id: `${manifestId}/c0/annotation`,
+        type: "Annotation",
+        motivation: "painting",
+        body: {
+          id: originalLink.href,
+          type: "Image",
+          format: "image/jpg",
+          height,
+          width,
+        } as any,
+      });
+    });
+  });
+
+  return builder.toPresentation3(builtManifest);
+}

--- a/src/generator/nasa-generator/query-string-stringify.ts
+++ b/src/generator/nasa-generator/query-string-stringify.ts
@@ -1,0 +1,17 @@
+export function queryStringStringify<T>(obj: T) {
+  const query = new URLSearchParams();
+
+  const keys = obj ? Object.keys(obj as any) : [];
+  for (const key of keys) {
+    const value = (obj as any)[key];
+    if (typeof value !== 'undefined' && value !== null) {
+      if (Array.isArray(value)) {
+        query.set(key, value.join(','));
+      } else {
+        query.set(key, value.toString());
+      }
+    }
+  }
+
+  return query.toString();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { build } from "./commands/build";
 import { serve } from "./commands/serve.ts";
 import { validate } from "./commands/validate.ts";
 import { init } from "./commands/init.ts";
+import { generate } from "./commands/generate.ts";
 
 const program = new Command();
 
@@ -25,6 +26,7 @@ program
   .option("--no-extract", "Disable extraction")
   .option("--no-enrich", "Disable enrichment")
   .option("--no-client", "Disable client.js building")
+  .option("--no-generate", "Disable IIIF generator")
   .option("--html", "Include HTML in build")
   .option("--python", "Allow python scripts")
   .option("--topics", "Flush topic data to /topics folder")
@@ -37,6 +39,13 @@ program
   .option("-d, --dev", "Development mode")
   .option("-s, --scripts <path>", "Build scripts")
   .action(serve);
+
+program
+  //
+  .command("generate")
+  .description("Run IIIF generators")
+  .option("--no-cache", "Disable caching")
+  .action(generate);
 
 program
   //

--- a/src/rewrite/flat-manifests.ts
+++ b/src/rewrite/flat-manifests.ts
@@ -1,0 +1,24 @@
+// Rewrite manifest paths to be flat.
+import { Rewrite } from "../util/rewrite.ts";
+
+export const flatManifests: Rewrite = {
+  id: "flat-manifests",
+  name: "Flat manifests",
+  types: ["Manifest", "Collection"],
+  rewrite: (slug, resource) => {
+    const isManifest = resource.type === "Manifest";
+    const isCollection = resource.type === "Collection";
+
+    if (isManifest) {
+      const parts = slug.split("/");
+      const lastPart = parts.pop();
+      return `manifests/${lastPart}`;
+    }
+    if (isCollection) {
+      const parts = slug.split("/");
+      const lastPart = parts.pop();
+      return `collections/${lastPart}`;
+    }
+    return slug;
+  },
+};

--- a/src/stores/iiif-json.ts
+++ b/src/stores/iiif-json.ts
@@ -72,10 +72,16 @@ async function parse(
 
   const manifests: ParsedResource[] = [];
   for (const [file, fileWithoutExtension] of newAllFiles) {
+    const fileType = await api.build.fileTypeCache.getFileType(file);
+    if (!fileType) {
+      api.build.log(
+        'Warning: Could not determine file type for "' + file + '"',
+      );
+    }
     manifests.push({
       path: file,
       slug: fileWithoutExtension,
-      type: "Manifest",
+      type: fileType || "Manifest",
       storeId: api.storeId,
       subFiles: subFileMap[fileWithoutExtension],
       source: { type: "disk", path: file },
@@ -161,7 +167,7 @@ async function load(
   return createProtoDirectory(
     {
       id,
-      type: "Manifest",
+      type: resource.type,
       path: resource.path,
       slug: resource.slug,
       storeId: resource.storeId,

--- a/src/stores/iiif-json.ts
+++ b/src/stores/iiif-json.ts
@@ -17,6 +17,7 @@ import objectHash from "object-hash";
 import { rewritePath } from "../util/rewrite-path.ts";
 import { readFilteredFiles } from "../util/read-filtered-files.ts";
 import { Manifest } from "@iiif/presentation-3";
+import { dirname } from "path/posix";
 
 export interface IIIFJSONStore {
   type: "iiif-json";
@@ -78,13 +79,24 @@ async function parse(
         'Warning: Could not determine file type for "' + file + '"',
       );
     }
+    let source: ProtoResourceDirectory["resource.json"]["source"] = {
+      type: "disk",
+      path: store.path,
+    };
+
+    if (store.path) {
+      const dir = dirname(file);
+      if (dir) {
+        source.relativePath = relative(store.path, dir);
+      }
+    }
     manifests.push({
       path: file,
       slug: fileWithoutExtension,
       type: fileType || "Manifest",
       storeId: api.storeId,
       subFiles: subFileMap[fileWithoutExtension],
-      source: { type: "disk", path: file },
+      source: source,
       saveToDisk: true,
     });
   }
@@ -100,9 +112,10 @@ export async function getKey(
   const key = file.mtime + "-" + file.ctime + "-" + file.size;
 
   if (store.subFiles) {
-    const subFilesFolder = existsSync(resource.slug);
+    const subFilesFolderPath = resource.path.replace(".json", "");
+    const subFilesFolder = existsSync(subFilesFolderPath);
     if (subFilesFolder) {
-      const allFiles = readAllFiles(resource.slug);
+      const allFiles = readAllFiles(subFilesFolderPath);
       const keys = [];
       for (const fileName of allFiles) {
         const file = await stat(fileName);
@@ -113,6 +126,7 @@ export async function getKey(
       return key + "_dir: " + dirHash;
     }
   }
+
   return key;
 }
 
@@ -146,15 +160,16 @@ async function load(
   }
 
   if (store.subFiles) {
-    const subFilesFolder = existsSync(resource.slug);
+    const subFilesFolderPath = resource.path.replace(".json", "");
+    const subFilesFolder = existsSync(subFilesFolderPath);
     if (subFilesFolder) {
       if (
         subFilesFolder &&
-        (await pathExists(resource.slug)) &&
-        !isEmpty(resource.slug)
+        (await pathExists(subFilesFolderPath)) &&
+        !isEmpty(subFilesFolderPath)
       ) {
         const destination = join(cwd(), directory, "files");
-        await copy(resource.slug, destination, { overwrite: true });
+        await copy(subFilesFolderPath, destination, { overwrite: true });
       }
     }
   }
@@ -173,7 +188,7 @@ async function load(
       storeId: resource.storeId,
       subResources: (res.items || []).length,
       saveToDisk: true,
-      source: { type: "disk", path: resource.path },
+      source: resource.source,
     },
     vault,
     { load: cacheKey },

--- a/src/util/extract.ts
+++ b/src/util/extract.ts
@@ -14,6 +14,14 @@ interface ExtractionSetupApi {
   config: IIIFRC;
 }
 
+export interface ExtractionReturn {
+  temp?: any;
+  caches?: Record<string, any>;
+  meta?: any;
+  indices?: Record<string, string[]>;
+  collections?: string[];
+}
+
 export interface Extraction<Config = any, Temp = any> {
   id: string;
   name: string;
@@ -44,10 +52,5 @@ export interface Extraction<Config = any, Temp = any> {
       build: BuildConfig;
     },
     config: Config,
-  ) => Promise<{
-    temp?: Temp;
-    caches?: Record<string, any>;
-    meta?: any;
-    indices?: Record<string, string[]>;
-  }>;
+  ) => Promise<ExtractionReturn>;
 }

--- a/src/util/file-type-cache.ts
+++ b/src/util/file-type-cache.ts
@@ -1,0 +1,53 @@
+import { existsSync } from "fs";
+
+export function createFiletypeCache(cacheFile: string) {
+  let isLoaded = false;
+  let didChange = false;
+  let fileTypeCache: Record<string, string> = {};
+
+  const loadIfExists = async () => {
+    if (isLoaded) return;
+    isLoaded = true;
+    if (existsSync(cacheFile)) {
+      fileTypeCache = await Bun.file(cacheFile).json();
+    }
+  };
+
+  return {
+    //
+    async getFileType(filePath: string) {
+      await loadIfExists();
+      if (fileTypeCache[filePath]) {
+        return fileTypeCache[filePath];
+      }
+
+      if (existsSync(filePath)) {
+        const jsonResource = await Bun.file(filePath).json();
+
+        let type = jsonResource.type || jsonResource["@type"];
+
+        switch (type) {
+          case "sc:Manifest":
+            type = "Manifest";
+            break;
+          case "sc:Collection":
+            type = "Collection";
+            break;
+        }
+
+        fileTypeCache[filePath] = type;
+
+        didChange = true;
+
+        return fileTypeCache[filePath];
+      }
+
+      return null;
+    },
+    async save() {
+      if (didChange) {
+        await Bun.write(cacheFile, JSON.stringify(fileTypeCache, null, 2));
+      }
+    },
+  };
+}

--- a/src/util/get-config.ts
+++ b/src/util/get-config.ts
@@ -8,6 +8,7 @@ export interface IIIFRC {
     url: string;
   };
   run?: string[];
+  generators?: Record<string, GeneratorConfig>;
   stores: Record<string, GenericStore>;
   slugs?: Record<string, SlugConfig>;
   config?: Record<string, any>;
@@ -26,6 +27,12 @@ export interface GenericStore {
   // Step options
   skip?: string[];
   run?: string[];
+  config?: Record<string, any>;
+}
+
+interface GeneratorConfig {
+  type: string;
+  output?: string;
   config?: Record<string, any>;
 }
 

--- a/src/util/get-node-globals.ts
+++ b/src/util/get-node-globals.ts
@@ -1,16 +1,23 @@
-import { Extraction } from './extract';
-import { Enrichment } from './enrich';
+import { Extraction } from "./extract";
+import { Enrichment } from "./enrich";
+import { Rewrite } from "./rewrite.ts";
+import { IIIFGenerator } from "./iiif-generator.ts";
 
 declare interface Global {
   __hss?: {
     extractions?: Extraction[];
     enrichments?: Enrichment[];
+    rewrites?: Rewrite[];
+    generators?: IIIFGenerator[];
   };
 }
 
 export function getNodeGlobals() {
   const extractions: Extraction[] = [];
   const enrichments: Enrichment[] = [];
+  const rewrites: Rewrite[] = [];
+  const generators: IIIFGenerator[] = [];
+
   const g = global as Global;
 
   if (g.__hss) {
@@ -20,6 +27,12 @@ export function getNodeGlobals() {
     if (g.__hss.enrichments) {
       enrichments.push(...g.__hss.enrichments);
     }
+    if (g.__hss.rewrites) {
+      rewrites.push(...g.__hss.rewrites);
+    }
+    if (g.__hss.generators) {
+      generators.push(...g.__hss.generators);
+    }
   }
-  return { extractions, enrichments };
+  return { extractions, enrichments, rewrites, generators };
 }

--- a/src/util/iiif-generator.ts
+++ b/src/util/iiif-generator.ts
@@ -1,0 +1,49 @@
+import { LazyValue } from "./lazy-value.ts";
+import { createStoreRequestCache } from "./store-request-cache.ts";
+
+export type GeneratorReference<T = any> = {
+  id: string;
+  type: "Manifest" | "Collection";
+  data: T;
+};
+
+type BaseApi<Config = any> = {
+  config: Config;
+  caches: LazyValue<Record<string, any>>;
+  cacheDirectory: string;
+  requestCache: ReturnType<typeof createStoreRequestCache>;
+};
+
+type GenerateApi<Config = any> = BaseApi<Config> & {
+  builder: any;
+  saveJson: (path: string, data: any) => void;
+};
+
+export interface IIIFGenerator<T = any, Config = any> {
+  id: string;
+  name: string;
+  prepare(api: BaseApi): Promise<Array<GeneratorReference<T>>>;
+  invalidateEach?: (
+    resource: GeneratorReference<T>,
+    api: BaseApi<Config>,
+  ) => Promise<boolean>;
+  invalidate?: (
+    resources: Array<GeneratorReference<T>>,
+    api: BaseApi<Config>,
+  ) => Promise<boolean>;
+  generateEach?: (
+    resource: GeneratorReference<T>,
+    directory: string,
+    api: GenerateApi<Config> & { builder: any },
+  ) => Promise<{ cache: any }>;
+  generate?: (
+    resources: Array<GeneratorReference<T>>,
+    directory: string,
+    api: GenerateApi<Config> & { builder: any },
+  ) => Promise<{ cache: any; store?: any }>;
+  postGenerate?: (
+    resources: Array<GeneratorReference<T>>,
+    directory: string,
+    api: GenerateApi<Config>,
+  ) => Promise<void>;
+}

--- a/src/util/load-scripts.ts
+++ b/src/util/load-scripts.ts
@@ -1,0 +1,47 @@
+import { join } from "node:path";
+import { cwd } from "node:process";
+import { existsSync } from "fs";
+import { readAllFiles } from "./read-all-files.ts";
+import { pythonExtract } from "./python-api.ts";
+import chalk from "chalk";
+
+export async function loadScripts(
+  options: { scripts?: string; python?: boolean; debug?: boolean },
+  log: (text: string) => void = () => void 0,
+) {
+  // Load external configs / scripts.
+  if (options.scripts) {
+    const scriptsPath = join(cwd(), options.scripts);
+    let loaded = 0;
+    if (existsSync(scriptsPath)) {
+      const allFiles = Array.from(readAllFiles(scriptsPath)).filter(
+        (s) => !s.endsWith("/hss.py"),
+      );
+      log(`Loading ${allFiles.length} script(s)`);
+      for (const file of allFiles) {
+        if (file.endsWith("extract.py")) {
+          if (options.python) {
+            loaded++;
+            await pythonExtract(file, options.debug);
+          }
+          // wrap enrichments in a function
+          continue;
+        }
+        if (file.endsWith(".py")) {
+          continue;
+        }
+
+        try {
+          await import(file);
+          loaded++;
+        } catch (e) {
+          console.log(chalk.red(e));
+          process.exit(1);
+        }
+      }
+      if (loaded !== allFiles.length) {
+        log(chalk.yellow(`Loaded ${loaded} of ${allFiles.length} scripts`));
+      }
+    }
+  }
+}

--- a/src/util/rewrite.ts
+++ b/src/util/rewrite.ts
@@ -1,0 +1,11 @@
+import { ParsedResource } from "./store.ts";
+
+export interface Rewrite {
+  id: string;
+  name: string;
+  types: string[];
+  rewrite?: (
+    slug: string,
+    resource: ParsedResource,
+  ) => string | Promise<string>;
+}

--- a/src/util/store.ts
+++ b/src/util/store.ts
@@ -71,7 +71,7 @@ export interface ProtoResourceDirectory {
      * Where this resource originated from.
      */
     source:
-      | { type: "disk"; path: string; alias?: string }
+      | { type: "disk"; path: string; alias?: string; relativePath?: string }
       | { type: "remote"; url: string; overrides?: string };
   };
   "vault.json": IIIFStore;


### PR DESCRIPTION
Adds a few more hooks and fixes some bugs.

Note: This release will not have a `build --watch` option. 

## Generators

A generator is a script that can be added to headless project that will be called before the rest of the pipeline. A generator will be tasked with creating a folder of IIIF manifests. It will be given a folder in the cache, and unless specified, the contents will automatically be added to the rest of the headless static site pipeline.

The generator is structured in a way to maximise caching, and parallelism. However, these are optional and you can just run it as a single monolithic function. The build-in example uses the NASA photo archive to make a search query and build manifests from the results. It uses the parallel steps.

All the steps available are:

- **Prepare** - this step is required, it _should_ return a list of expected Manifests to be generated. However, this step can also just be used for the whole generation. It is ALWAYS called when a build/generation happens. Any caching here would have to be manual. However a cached `fetch()` is provided.
- **Invalidate** - this is a function that returns a boolean. If it returns `true` then the following generate steps will be called.
- **Generate Each** - The list of resources returned in the prepare step are gathered and in parallel the `generateEach` is called on them. Useful for async requests. Currently the generator does not have batching, so be careful if you are making lots of HTTP requests. In the generate you are passed a directory to save the resource, along with the data returned in the prepare step and caches. Similar to other steps in the pipeline you can return cache entries specific to this resource (by id) using `return { cache: { anything: '...' } }`
- **Generate** - This is similar to Generate Each, but is only called once and passed a list of all the resources. It also has a single cache. You can implement both steps, or just one.
- **Post generate** - This is called after the previous generation steps are done. You are passed the list of resources and the directory that they should now be saved to.

There is also an `invalidateEach` step that will be passed the resource-specific cache from the `generateEach` step, so you can only build things that have changed.

The NASA example uses:
- Prepare
- Genrate Each

The prepare step makes the search request to the NASA API and returns a list of results. It uses the configuration from the `.iiifrc.yaml` to limit the results and pages. It then returns a list of resources (NOT IIIF YET). E.g.

```js
return [
  {
    id: 'KSC-97PC1225',
    type: 'Manifest',
    data: { nasa_id: 'KSC-97PC1225' }
  }
];
```

The identifier needs to be unique, but doesn't have to be a URL and the data can be anything serialisable. 

The returned list of results are then passed to `generateEach` which will make a further call to the NASA APIs to get image information and metadata. It will then construct a IIIF Manifest (using IIIF Builder, instance passed in as a helper) and save it to disk.

There is a helper for saving data to disk (save and forget, no await). 

If there is no `output` in the `iiifrc.yaml` configuration, then it will be automatically build into the static site using the `iiif-json` preset. You can the "virtual" store it generates in the build folder (`.iiif/build/config/stores.json`). If you set an output folder, that will be used for building instead - and then you can wire it up manually, if you want to save into source control or change the filter rules.

Example `.iiifrc.yaml` using the build in example generator (NASA)

```yaml
server:
  url: http://localhost:7111

generators:
  sts-shuttles:
    type: nasa-generator
    config:
      label: STS Shuttles
      query: "sts orbit"
      maxResults: 10
```

By default, generators will be run during a build. But you can pass `--no-generate` to prevent this. You can also run generate as a distinct step using `iiif-hss generate`

Caching is aggressive, but `--no-cache` will disable the remote URL cache for generators.

To create a new generator, you can create a script - similar to extract/enrich.
```js
import { generator } from 'iiif-hss';

generator({
  id: 'my-generator',
  name: 'My generator',
  async prepare() {
    return [ ... ];
  },
  async generate(list, dir, api) {
    // ...
  }
})

```

## Rewrites

A new hook was added for rewriting slugs. This is always called, so ideally the generation of the rewrite should be minimal and not make slow requests. There is a bundled rewrite for flattening manifests/collections. If you implemented this in the `scripts/` folder, it might look like this

```js
// scripts/flat-manifests.js
import { rewrite } from 'iiif-hss';

rewrite({
  id: 'flat-manifests',
  name: 'Flat manifests',
  types: ['Manifest'],
  rewrite(slug, resource) {
    const parts = slug.split('/');
    const lastPart = parts.pop();
    return `manifests/${lastPart}`;
  },
});
```

This will rewrite the slug (the URL of the manifest, minus the `/manifest.json` at the end). Currently rewrites can only be added to the top-level `run:` in the config, and not per-store. This might change in the future, but you need to ensure you add it into the run configuration.

## Generic collections
There is some work to do with collection processing, and this feature is a functional but not customisable implementation of creating generic collections during the `extract` step.

In addition to returning indicies, caches and meta from an extraction step, you can also return a list of collection slugs. e.g. `path/to/my/collection`. All manifests that are tagged in this way will be gathered together and a IIIF collection created. The labels are bad and you cannot customise them yet. However there is a plan to improve the collection enrichment step, including these collections and index collections.

There is a built-in generic collection extraction: `folder-collections`. This will create a collection from each folder that contains manifests. 

For example:
```
exhibitions/manifest-1.json
exhibitions/manifest-2.json
exhibitions/manifest-3.json
objects/manifest-4.json
objects/manifest-5.json
objects/manifest-6.json
```
Will create 2 collections, each with 3 manifests:
```
collections/exhibitions/collection.json
collections/objects/collection.json
```

And if you pair this will flat manifests, they would be rewritten to:
```
manifests/manifest-1.json
manifests/manifest-2.json
manifests/manifest-3.json
manifests/manifest-4.json
manifests/manifest-5.json
manifests/manifest-6.json
```

So they are flat, but you have the folder structure preserved.