### PR TITLE
Search index and topic improvements

### DIFF
--- a/src/enrich/typesense-index.ts
+++ b/src/enrich/typesense-index.ts
@@ -59,11 +59,11 @@ export const enrichTypesense: Enrichment<{}, { record: SingleRecord; foundTopics
       extraTopics[`topic_${k}`] = v;
     }
 
-    let plaintext = '';
-    const keywordsFile = join(api.files, 'keywords.txt');
-    if (existsSync(keywordsFile)) {
-      plaintext = await readFile(keywordsFile, 'utf-8');
-    }
+    // let plaintext = '';
+    // const keywordsFile = join(api.files, 'keywords.txt');
+    // if (existsSync(keywordsFile)) {
+    //   plaintext = await readFile(keywordsFile, 'utf-8');
+    // }
     const collections = meta.partOfCollections || [];
 
     return {
@@ -79,7 +79,7 @@ export const enrichTypesense: Enrichment<{}, { record: SingleRecord; foundTopics
           url: meta.url,
           totalItems: meta.totalItems,
           collections: collections.map((c: any) => c.slug),
-          plaintext,
+          plaintext: api.resource.metadata.map((m: any) => getValue(m.value)).join(' '),
           ...extraTopics,
         },
         foundTopics: Object.keys(extraTopics),

--- a/src/extract/extract-topics.ts
+++ b/src/extract/extract-topics.ts
@@ -1,18 +1,20 @@
-import { Extraction } from "../util/extract.ts";
-import { getValue } from "@iiif/helpers/i18n";
-import { getSingleLabel } from "../util/get-single-label.ts";
+import { Extraction } from '../util/extract.ts';
+import { getValue } from '@iiif/helpers/i18n';
+import { getSingleLabel } from '../util/get-single-label.ts';
 
 interface ExtractTopicsConfig {
   language?: string;
   translate?: boolean;
+  upperCase?: boolean;
+  dateRange?: string[];
   commaSeparated?: string[];
   topicTypes: Record<string, string | string[]>; // e.g. { author: ['Author', 'Written by'] } and it will look in the metadata for these.
 }
 
 export const extractTopics: Extraction<ExtractTopicsConfig> = {
-  id: "extract-topics",
-  name: "Extract Topics",
-  types: ["Manifest"],
+  id: 'extract-topics',
+  name: 'Extract Topics',
+  types: ['Manifest'],
 
   invalidate: async () => {
     return true;
@@ -22,17 +24,17 @@ export const extractTopics: Extraction<ExtractTopicsConfig> = {
     const {
       commaSeparated = [],
       translate = true,
+      upperCase = true,
+      dateRange = [],
       topicTypes = {},
-      language = "en",
+      language = 'en',
     } = config;
 
     const topicsToParse = Object.keys(topicTypes);
     const latestResource = resource.vault?.get(api.resource);
     const metadata = latestResource?.metadata || [];
     const metadataLabels: string[] = await Promise.all(
-      metadata.map((item: any) =>
-        getSingleLabel(item.label, { language, translate }),
-      ),
+      metadata.map((item: any) => getSingleLabel(item.label, { language, translate }))
     );
 
     const indices: Record<string, string[]> = {};
@@ -44,18 +46,35 @@ export const extractTopics: Extraction<ExtractTopicsConfig> = {
         if (index === -1) {
           continue;
         }
+
+        const arrayRange = ([start, stop]: number[]) =>
+          Array.from({ length: stop - start + 1 }, (value, index) => (start + index).toString());
+
+        const makeUpperCase = (string: string) =>
+          upperCase ? string.charAt(0).toUpperCase() + string.slice(1) : string;
+
         const values = metadata[index].value;
         const first = Object.keys(values)[0];
         const value = values[first] as string[];
         if (value) {
-          if (commaSeparated.includes(topic)) {
+          indices[topic] = indices[topic] || [];
+          if (dateRange.includes(topic)) {
             value.forEach((v) => {
-              indices[topic] = indices[topic] || [];
-              indices[topic].push(...v.split(",").map((t) => t.trim()));
+              if (v.includes('-')) {
+                const range = arrayRange(v.split('-').map((d) => +d));
+                indices[topic].push(...range);
+              } else {
+                indices[topic].push(v);
+              }
+            });
+          } else if (commaSeparated.includes(topic)) {
+            value.forEach((v) => {
+              indices[topic].push(...v.split(',').map((t) => makeUpperCase(t.trim())));
             });
           } else {
-            indices[topic] = indices[topic] || [];
-            indices[topic].push(...value);
+            value.forEach((v) => {
+              indices[topic].push(makeUpperCase(v.trim()));
+            });
           }
         }
       }


### PR DESCRIPTION
## Search index
- Metadata values are now added to the `plaintext` field to be indexed by Typesense.

_This currently may include html tags if present in the source manifest._

## Topics
- Added function to capitalize the first character of topics

This can be disabled as follows:

```yml
    config:
      extract-topics:
        upperCase: false
```

- Added an option to create date ranges

This can be enabled as follows:

```yml
    config:
      extract-topics:
        dateRange: ["date"]
        topicTypes:
          date: ['Date', 'Datering']
```

This will process metadata values such as `1900 - 1925` and create collections within the `date` topic for all years in between: `1900`, `1901`, ... `1924`, `1925`.

Todo: add an integer field to the Typesense index with the year values.